### PR TITLE
Changed AppAuth to use ExternalUserAgent subspec

### DIFF
--- a/GTMAppAuth.podspec
+++ b/GTMAppAuth.podspec
@@ -44,5 +44,5 @@ requests with AppAuth.
 
   s.frameworks = 'Security', 'SystemConfiguration'
   s.dependency 'GTMSessionFetcher', '~> 1.1'
-  s.dependency 'AppAuth/Core', '~> 1.0'
+  s.dependency 'AppAuth/ExternalUserAgent', '~> 1.0'
 end


### PR DESCRIPTION
This spec contains `OIDAuthState+IOS.h` extension which is needed to work with iOS.